### PR TITLE
Fixed Texture and Image usage in TextureManager.gd

### DIFF
--- a/TextureManager.gd
+++ b/TextureManager.gd
@@ -3,14 +3,10 @@ extends TextureRect
 @onready var grid_size = get_node("../LifeCompute").grid_size
 
 func _ready():
-	var image = Image.new()
-	image.create(grid_size.x + 2, grid_size.y + 2, false, Image.FORMAT_RF)
-	var image_texture = ImageTexture.new()
-	image_texture.create_from_image(image)
-	texture = image_texture
+	var image = Image.create(grid_size.x + 2, grid_size.y + 2, false, Image.FORMAT_RF)
+	texture = ImageTexture.create_from_image(image)
 
 
 func set_data(data : PackedByteArray):
-	var image = texture.get_image()
-	image.create_from_data(grid_size.x + 2, grid_size.y + 2, false, Image.FORMAT_RF, data)
+	var image = Image.create_from_data(grid_size.x + 2, grid_size.y + 2, false, Image.FORMAT_RF, data)
 	texture.update(image)


### PR DESCRIPTION
I am using a more recent version of Godot (v4.0.stable.official [92bee43ad]). I'm guessing these APIs used to work differently, but currently, the `create` methods for `Image` and `ImageTexture` are static (should be invoked on the class instead of an instance).